### PR TITLE
Remove cookie-based token handling

### DIFF
--- a/src/main/java/org/example/agent/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/agent/domain/auth/controller/AuthController.java
@@ -8,7 +8,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.agent.config.JwtEncryptProperties;
 import org.example.agent.domain.auth.dto.AuthUserDto;
 import org.example.agent.domain.auth.service.AuthTokenService;
 import org.example.agent.domain.auth.service.AuthUserService;
@@ -42,7 +41,6 @@ import static org.example.agent.global.constrant.GlobalConst.BASE_URL;
 @RequestMapping(BASE_URL)
 @RequiredArgsConstructor
 public class AuthController {
-    private final JwtEncryptProperties jwtEncryptProperties;
     private final AuthUserService authUserService;
     private final TokenEncryptService tokenEncryptService;
     private final AuthTokenService authTokenService;
@@ -82,7 +80,7 @@ public class AuthController {
 
         authUserService.save(authUserEntity);
 
-        TokenIssueFunction.issueToken(newToken, jwtEncryptProperties, servletResponse);
+        TokenIssueFunction.issueToken(newToken, servletResponse);
 
         return ResponseEntity.ok().body(
                 ResponseResult.of(

--- a/src/main/java/org/example/agent/global/util/TokenIssueFunction.java
+++ b/src/main/java/org/example/agent/global/util/TokenIssueFunction.java
@@ -1,30 +1,18 @@
 package org.example.agent.global.util;
 
 import jakarta.servlet.http.HttpServletResponse;
-import org.example.agent.config.JwtEncryptProperties;
 import org.example.agent.global.security.response.TokenResponse;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
-
-import java.time.Duration;
 
 public class TokenIssueFunction {
 
+    private static final String REFRESH_HEADER = "Refresh-Token";
+
     public static void issueToken(TokenResponse tokenResponse,
-                                  JwtEncryptProperties jwtEncryptProperties,
                                   HttpServletResponse response) {
 
-        // HttpOnly 쿠키로 전달(보안/간편)
-        ResponseCookie access = ResponseCookie.from("ACCESS_TOKEN", tokenResponse.accessToken())
-                .httpOnly(true).secure(true).sameSite("Lax").path("/")
-                .maxAge(Duration.ofSeconds(jwtEncryptProperties.getExpireAccessTokenSecond())).build();
-
-        ResponseCookie refresh = ResponseCookie.from("REFRESH_TOKEN", tokenResponse.refreshToken())
-                .httpOnly(true).secure(true).sameSite("Lax").path("/")
-                .maxAge(Duration.ofSeconds(jwtEncryptProperties.getExpireRefreshTokenSecond())).build();
-
-        response.addHeader(HttpHeaders.SET_COOKIE, access.toString());
-        response.addHeader(HttpHeaders.SET_COOKIE, refresh.toString());
+        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + tokenResponse.accessToken());
+        response.setHeader(REFRESH_HEADER, tokenResponse.refreshToken());
     }
 
 }


### PR DESCRIPTION
## Summary
- issue JWT access and refresh tokens via response headers
- read refresh tokens from `Refresh-Token` header instead of cookies
- adjust auth endpoints and OAuth2 login to use header-based token delivery

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68b2acecc120832fb043025cef699ac8